### PR TITLE
add a way to get all installed plugins version

### DIFF
--- a/JumpScale9/core/State.py
+++ b/JumpScale9/core/State.py
@@ -14,6 +14,14 @@ class State():
         self.config = None
 
     @property
+    def versions(self):
+        versions = {}
+        for name, path in self.config.get('plugins', {}).items():
+            repo = j.clients.git.get(path)
+            _, versions[name] = repo.getBranchOrTag()
+        return versions
+
+    @property
     def db(self):
         return None
         if self._db is None and j.clients is not None:


### PR DESCRIPTION
#### What this PR resolves:
add a way to get all installed plugins version

#### Changes proposed in this PR:

- Add a version property to `j.core.state` where we can inspect all plugins version


**Version**:  9.0

**Fixes**: #14