### PR TITLE
Adds make j.dirs consistent  local prefab dir_paths

### DIFF
--- a/JumpScale9/core/Dirs.py
+++ b/JumpScale9/core/Dirs.py
@@ -34,6 +34,7 @@ class Dirs:
 
         for key, val in j.core.state.config["dirs"].items():
             self.__dict__[key] = val
+            os.environ[key] = val
 
     def replaceTxtDirVars(self, txt, additionalArgs={}):
         """


### PR DESCRIPTION
related to https://github.com/Jumpscale/prefab9/issues/11

Signed-off-by: Ashraf Fouda <ashraf.m.fouda@gmail.com>


#### What this PR resolves:
https://github.com/Jumpscale/prefab9/issues/11


#### Changes proposed in this PR:

- j.dirs gets its values from jumpscal9.toml and prefab dirpaths gets its dirs from env. So I add the dirs we get from jumpscale9.toml to the env


**Version**: 

**Fixes**: #
