### PR TITLE
Fix generatePlugins call in js9_init

### DIFF
--- a/cmds/js9_init
+++ b/cmds/js9_init
@@ -16,4 +16,4 @@ import sys
 print(j.do.mascot)
 
 j.do.debug = False
-j.tools.jsloader.generatePlugins()
+j.tools.jsloader.generateJumpscalePlugins()


### PR DESCRIPTION
#### What this PR resolves:
the install error when call js9_init

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
