### PR TITLE
Change the error msg to include the repo name #69

### DIFF
--- a/JumpScale9/core/InstallTools.py
+++ b/JumpScale9/core/InstallTools.py
@@ -692,8 +692,12 @@ class GitMethods():
                 # raise RuntimeError("Cannot retrieve branch:\n%s\n" % cmd)
             if branch is not None and branch != branchFound and ignorelocalchanges is False:
                 raise RuntimeError(
-                    "Cannot pull repo, branch on filesystem is not same as branch asked for.\nBranch asked for:%s\nBranch found:%s\nTo choose other branch do e.g:\nexport JSBRANCH='%s'\n" %
-                    (branch, branchFound, branchFound))
+                    "Cannot pull repo '%s', branch on filesystem is not same as branch asked for.\n"
+                    "Branch asked for: %s\n"
+                    "Branch found: %s\n"
+                    "To choose other branch do e.g:\n"
+                    "export JSBRANCH='%s'\n" %
+                    (repo, branch, branchFound, branchFound))
 
             if ignorelocalchanges:
                 self.logger.info(

--- a/JumpScale9/core/InstallTools.py
+++ b/JumpScale9/core/InstallTools.py
@@ -695,7 +695,7 @@ class GitMethods():
                     "Cannot pull repo '%s', branch on filesystem is not same as branch asked for.\n"
                     "Branch asked for: %s\n"
                     "Branch found: %s\n"
-                    "To choose other branch do e.g:\n"
+                    "To choose other branch do e.g:"
                     "export JSBRANCH='%s'\n" %
                     (repo, branch, branchFound, branchFound))
 


### PR DESCRIPTION
#### What this PR resolves:
Changes the unclear error message shown while pulling repo branches if weren't the same as local one

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
