### PR TITLE
set process check log to debug level

### DIFF
--- a/JumpScale9/sal/process/SystemProcess.py
+++ b/JumpScale9/sal/process/SystemProcess.py
@@ -658,7 +658,7 @@ class SystemProcess:
         @param min: (int) minimal threads that should run.
         @return True if ok
         """
-        self.logger.info('Checking whether at least %d processes %s are running' % (min, process))
+        self.logger.debug('Checking whether at least %d processes %s are running' % (min, process))
         if j.core.platformtype.myplatform.isUnix:
             pids = self.getProcessPid(process)
             if len(pids) >= min:


### PR DESCRIPTION
#### What this PR resolves:
Process check logs appear only when log level is set to debug 


**Version**: 9.1.1

**Fixes**: #https://github.com/Jumpscale/core9/issues/59
