### PR TITLE
executor dir paths

### DIFF
--- a/JumpScale9/tools/executor/ExecutorBase.py
+++ b/JumpScale9/tools/executor/ExecutorBase.py
@@ -333,7 +333,11 @@ class ExecutorBase:
     @property
     def dir_paths(self):
         if "dirs" not in self.config:
-            self.initEnv()
+            if self.exists(self.state.configPath):
+                self.config = self.state.config
+            else:
+                dirConfig = self._getDirPathConfig()
+                self.config['dirs'] = pytoml.loads(dirConfig)
         return self.config["dirs"]
 
 


### PR DESCRIPTION
#### What this PR resolves:
Returning default jumpscale dir paths when accessing a remote machine using ssh. If the remote has jumpscale env it will use its configuration.

 

**Fixes**: #https://github.com/Jumpscale/ays9/issues/221
