### PR TITLE
Run commands for j.sal.execute using bash

### DIFF
--- a/JumpScale9/sal/process/SystemProcess.py
+++ b/JumpScale9/sal/process/SystemProcess.py
@@ -64,6 +64,7 @@ class SystemProcess:
             command = "bash %s" % path
         else:
             # self.logger.info("exec:%s" % command)
+            command = "bash -c '%s'" % command
             path = None
 
         os.environ["PYTHONUNBUFFERED"] = "1"


### PR DESCRIPTION
 to avoid using sh as a default #70


#### What this PR resolves:


#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #70
