### PR TITLE
Fix permission denied error when execute on a remote host

### DIFF
--- a/JumpScale9/core/State.py
+++ b/JumpScale9/core/State.py
@@ -194,8 +194,8 @@ class State():
         print (path)
 
         cdict={}
-        cdict["me"]=self.config["me"]
-        cdict["email"]=self.config["email"]
+        cdict["me"]=self.config.get("me")
+        cdict["email"]=self.config.get("email")
 
         if self.executor == j.tools.executorLocal:
             # print("configsave state me on %s" % path)

--- a/JumpScale9/tools/bash/BashFactory.py
+++ b/JumpScale9/tools/bash/BashFactory.py
@@ -238,7 +238,7 @@ class Bash:
 
     @property
     def home(self):
-        return self.executor.dir_paths["HOMEDIR"]
+        return self.executor.env.get("HOME") or self.executor.dir_paths["HOMEDIR"]
 
     def cmdGetPath(self, cmd, die=True):
         """


### PR DESCRIPTION
#### What this PR resolves:
When prefab is used to execute commands on a remote machine the user has no access to /root so it gives permission denied

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
