### PR TITLE
minor bug fix

### DIFF
--- a/JumpScale9/tools/executor/ExecutorBase.py
+++ b/JumpScale9/tools/executor/ExecutorBase.py
@@ -445,7 +445,7 @@ class ExecutorBase:
 
     @property
     def dir_paths(self):
-        if not self.state.configGet('dirs', None):
+        if not self.state.configGet('dirs', []):
                 self.initEnv()
         return self.state.configGet("dirs")
 


### PR DESCRIPTION
#### What this PR resolves:

get prefab on remote nodes does not work due to bug in dirs_path method in executor base fixed for now until code from master is ported to 9.3.0

#### Changes proposed in this PR:

- default to empty [] instead of none 
-


**Version**: 

**Fixes**: #
