### PR TITLE
executor dir paths

### DIFF
--- a/JumpScale9/tools/executor/ExecutorBase.py
+++ b/JumpScale9/tools/executor/ExecutorBase.py
@@ -445,9 +445,11 @@ class ExecutorBase:
 
     @property
     def dir_paths(self):
-        if not self.state.configGet('dirs', []):
-                self.initEnv()
-        return self.state.configGet("dirs")
+        if self.exists(self.state.configJSPath):
+            return self.state.configGet('dirs')
+        else:
+            dir_config = self._getDirPathConfig()
+            return pytoml.loads(dir_config)
 
     @property
     def platformtype(self):


### PR DESCRIPTION
#### What this PR resolves:
Don't use `initEnv` when using remote executor.

#### Changes proposed in this PR:

- If there is no config file on the machine it will use the default JumpScale dir paths.



**Version**: 9.3.0

**Fixes**: https://github.com/Jumpscale/core9/issues/110
