### PR TITLE
dir paths for remote executor

### DIFF
--- a/JumpScale9/core/State.py
+++ b/JumpScale9/core/State.py
@@ -9,7 +9,7 @@ class State():
 
     """
 
-    def __init__(self, executor, configPath=""):
+    def __init__(self, executor):
         self.readonly = False
         self.executor = executor
         self.load()
@@ -39,7 +39,6 @@ class State():
 
     def stateSet(self, key, val, save=True):
         return self._set(key=key, val=val, save=save, config=self._configState, path=self.configStatePath)
-
 
     def stateGet(self, key, defval=None, set=False):
         return self._get(key=key, defval=defval, set=set, config=self._configState, path=self.configStatePath)
@@ -90,15 +89,13 @@ class State():
             val2 = None
         if val != val2:
             config[key] = val
-            # print("config set %s:%s" % (key, val))
-            # print("config changed")
             self._config_changed = True
             if save:
-                self.configSave(path)
+                self.configSave(config, path)
             return True
         else:
             if save:
-                self.configSave(path)
+                self.configSave(config, path)
             return False
     def configSetInDict(self, key, dkey, dval):
         self._setInDict(key=key, dkey=dkey, dval=dval, config=self._configJS, path=self.configJSPath)

--- a/JumpScale9/tools/executor/ExecutorBase.py
+++ b/JumpScale9/tools/executor/ExecutorBase.py
@@ -446,6 +446,8 @@ class ExecutorBase:
     @property
     def dir_paths(self):
         if self.exists(self.state.configJSPath):
+            if not self.state.configGet('dirs', {}):
+                self.reset()
             return self.state.configGet('dirs')
         else:
             dir_config = self._getDirPathConfig()


### PR DESCRIPTION
#### What this PR resolves:
- Use remote's machine JumpScale directories when using remote executor if the configuration exists. 
- When changing state info only write to `state.toml`.
