### PR TITLE
don't delete js9.toml when installing js9core

### DIFF
--- a/JumpScale9/core/State.py
+++ b/JumpScale9/core/State.py
@@ -107,6 +107,7 @@ class State():
             if save:
                 self.configSave(config, path)
             return False
+
     def configSetInDict(self, key, dkey, dval):
         self._setInDict(key=key, dkey=dkey, dval=dval, config=self._configJS, path=self.configJSPath)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ def _post_install(libname, libpath):
     # remove leftovers
     for item in j.sal.fs.find("/usr/local/bin/",fileregex="js9*"):
          j.sal.fs.remove("/usr/local/bin/%s"%item)
-    j.sal.fs.remove(j.sal.fs.joinPaths(j.dirs.HOMEDIR,".jumpscale9.toml"))
 
     j.tools.executorLocal.initEnv()
     j.tools.jsloader.generate()


### PR DESCRIPTION
Signed-off-by: Khaled K. Badr <khaledkbadr@outlook.com>

#### Changes proposed in this PR:

- don't delete js9.toml when installing js9core


**Version**: 9.3.0

**Hardening for**: https://github.com/Jumpscale/portal9/issues/99
