### PR TITLE
add clientConfigSet and clientConfigList to State object

### DIFF
--- a/JumpScale9/core/State.py
+++ b/JumpScale9/core/State.py
@@ -3,15 +3,17 @@ from JumpScale9 import j
 import sys
 import os
 
+
 class ClientConfig():
-    def __init__(self, category,instance):
-        self.category=category
-        self.instance=instance
-        self.key="client_%s_%s"%(self.category,self.instance)
-        self.data=j.core.state.configGet(self.key,defval={})
+
+    def __init__(self, category, instance):
+        self.category = category
+        self.instance = instance
+        self.key = "client_%s_%s" % (self.category, self.instance)
+        self.data = j.core.state.configGet(self.key, defval={})
 
     def save(self):
-        j.core.state.configSet(self.key,self.data)
+        j.core.state.configSet(self.key, self.data)
 
 
 class State():
@@ -235,13 +237,41 @@ class State():
         data = pytoml.dumps(self._configState)
         self.executor.file_write(self.configStatePath, data)
 
-    def clientConfigGet(self,category,instance):
+    def clientConfigGet(self, category, instance):
         """
         @PARAm category e.g. openvcloud
         @PARAM instance e.g. gig1
         """
-        return ClientConfig(category,instance)
+        return ClientConfig(category, instance)
 
+    def clientConfigSet(self, category, instance, data):
+        """
+        Attach client config data to the category and instance
+
+        @param category: name of the client category
+        @param instance: instance name of the client
+        @param data: dictionnary of data attached to the category and instance
+        """
+        if not isinstance(data, dict):
+            raise ValueError('data should be a dict, not %s' % type(data))
+        cfg = ClientConfig(category, instance)
+        cfg.data = data
+        cfg.save()
+
+    def clientConfigList(self, category):
+        """
+        List all client configuration stored for category
+        @param category: name of the client category
+
+        @return:  list of ClientConfig object
+        """
+        prefix = "client_%s" % category
+        out = []
+        for key, val in self._configJS.items():
+            if key.startswith(prefix):
+                instance = key[len(prefix) + 1:]
+                out.append(ClientConfig(category, instance))
+        return out
 
     def reset(self):
         self._configJS = {}

--- a/JumpScale9/core/test_State.py
+++ b/JumpScale9/core/test_State.py
@@ -1,0 +1,68 @@
+import pytest
+import tempfile
+from js9 import j
+
+from .State import ClientConfig, State
+
+
+class TestStateClientConfig:
+
+    def setup_method(self):
+        temp_dir = j.sal.fs.getTmpDirPath()
+        j.core.state.configJSPath = temp_dir + "/jumpscale9.toml"
+        j.core.state.configStatePath = temp_dir + "/state.toml"
+        j.core.state.configMePath = temp_dir + "/me.toml"
+
+        j.core.state._configState = {}
+        j.core.state._configJS = {}
+        j.core.state.configMe = {}
+
+    def teardown_method(self):
+        j.core.state.configJSPath = j.core.state.executor.stateOnSystem["path_jscfg"] + "/jumpscale9.toml"
+        j.core.state.configStatePath = j.core.state.executor.stateOnSystem["path_jscfg"] + "/state.toml"
+        j.core.state.configMePath = j.core.state.executor.stateOnSystem["path_jscfg"] + "/me.toml"
+        j.core.state._configState = j.core.state.executor.stateOnSystem["cfg_state"]
+        j.core.state._configJS = j.core.state.executor.stateOnSystem["cfg_js9"]
+        j.core.state.configMe = j.core.state.executor.stateOnSystem["cfg_me"]
+
+    def test_clientConfigSetGet(self):
+        category = 'test'
+        instance = 'foo'
+        data = {'hello': 'world'}
+        j.core.state.clientConfigSet(category, instance, data)
+
+        cfg = j.core.state.clientConfigGet('test', 'foo')
+        assert cfg.data == data
+        assert cfg.category == category
+        assert cfg.instance == instance
+        assert cfg.key == "client_%s_%s" % (category, instance)
+
+        # when getting from non existing instance, return an empty ClientConfig
+        instance = 'nonexists'
+        cfg = j.core.state.clientConfigGet(category, instance)
+        assert cfg.data == {}
+        assert cfg.category == category
+        assert cfg.instance == instance
+        assert cfg.key == "client_%s_%s" % (category, instance)
+
+    def test_clientConfigSetGet_wrong_data_type(self):
+        with pytest.raises(ValueError):
+            j.core.state.clientConfigSet('test', 'foo', "string")
+        with pytest.raises(ValueError):
+            j.core.state.clientConfigSet('test', 'foo', 1)
+        with pytest.raises(ValueError):
+            j.core.state.clientConfigSet('test', 'foo', ['hello', 'world'])
+
+    def test_clientConfigList(self):
+        # set some config
+        category = 'test'
+        instance = 'foo'
+        data = {'hello': 'world'}
+        j.core.state.clientConfigSet(category, instance + "1", data)
+        j.core.state.clientConfigSet(category, instance + "2", data)
+
+        cfgs = j.core.state.clientConfigList(category)
+        assert len(cfgs) == 2
+
+        cfgs = j.core.state.clientConfigList('nonexists')
+        assert len(cfgs) == 0


### PR DESCRIPTION
#### What this PR resolves:
Add missing method to set and list a client config from the jumpscale state.
Before this PR only get method was available. 