### PR TITLE
remove pyserial from setup(comes with default python3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
         'msgpack-python',
         'npyscreen',
         'pyyaml',
-        'pyserial>=3.4',
         'docker>=3',
         'fakeredis',
         'ssh2-python',


### PR DESCRIPTION
#### What this PR resolves:
Removes pyserial import since it is packaged with default python3. Which causes trouble when trying to reinstall it since it is a distutils installed project

**Fixes**: #https://github.com/Jumpscale/core9/issues/224
