### PR TITLE
set the proper log level for all new loggers

### DIFF
--- a/JumpScale9/logging/LoggerFactory.py
+++ b/JumpScale9/logging/LoggerFactory.py
@@ -81,6 +81,7 @@ class LoggerFactory():
                 # print("JSLOGGER:%s" % name)
                 # logger = logging.getLogger(name)
                 logger = JSLogger(name)
+                logger.level = j.core.state.configGetFromDict("logging", "level", 'DEBUG')
 
                 for handler in self.handlers._all:
                     logger.handlers = []
@@ -261,7 +262,9 @@ class LoggerFactory():
         get info from config file & make sure all logging is done properly
         """
         self.enabled = j.core.state.configGetFromDict("logging", "enabled", True)
-        self.loggers_level_set(j.core.state.configGetFromDict("logging", "level", 'DEBUG'))
+        level = j.core.state.configGetFromDict("logging", "level", 'DEBUG')
+        self.loggers_level_set(level)
+        self.handlers_level_set(level)
         self.filter = []
         self.exclude = []
         self.loggers = {}


### PR DESCRIPTION
#### What this PR resolves:
logger level from configuration is not used by evey logger

#### Changes proposed in this PR:

- set logger level from config to all new logger 

I'm not fully sure this is a 100% correct fix, cause I seems that some of the logger endup beeing created here: https://github.com/Jumpscale/core9/blob/8936c330a6322a3a411f61d38a327cff2a12facc/JumpScale9/logging/LoggerFactory.py#L77
while some other are created there: https://github.com/Jumpscale/core9/blob/8936c330a6322a3a411f61d38a327cff2a12facc/JumpScale9/logging/LoggerFactory.py#L83

I don't know if that shows a bug in higher level or how the logger is created, but seems the logger created at https://github.com/Jumpscale/core9/blob/8936c330a6322a3a411f61d38a327cff2a12facc/JumpScale9/logging/LoggerFactory.py#L83 doesn't get their level properly set, that' what I'm solving in the PR